### PR TITLE
Fix copyright license header year on an-excited-time-drawing-mandala-fractals-today-2023-04-06

### DIFF
--- a/math/swe/drawing/an-excited-time-drawing-mandala-fractals-today-2023-04-06/index.md
+++ b/math/swe/drawing/an-excited-time-drawing-mandala-fractals-today-2023-04-06/index.md
@@ -1,4 +1,4 @@
-<!-- Copyright (c) 2022-present Tobias Briones. All rights reserved. -->
+<!-- Copyright (c) 2023 Tobias Briones. All rights reserved. -->
 <!-- SPDX-License-Identifier: CC-BY-4.0 -->
 <!-- This file is part of https://github.com/tobiasbriones/blog -->
 


### PR DESCRIPTION
I had copied with year 2022, and the "-present" boilerplate is not needed.