### PR TITLE
Fix code snippet captions on pi-day-2023-03-14

### DIFF
--- a/math/pi-day-2023-03-14/index.md
+++ b/math/pi-day-2023-03-14/index.md
@@ -47,9 +47,12 @@ fib 1 = 1
 fib n = fib (n-1) + fib (n-2)
 ```
 
+<p align="center">
+Also Known as "the 'Hello, world!' of Haskell programming"
+</p>
+
 <figcaption>
-<p align="center"><strong>The Fibonacci Sequence (a.k.a. "the 'Hello, world!' 
-of Haskell programming"</strong>[4]</p>
+<p align="center"><b>The Fibonacci Sequence</b> [4]</p>
 </figcaption>
 
 The declarativeness of math enables creation with mathematical elegance unlike


### PR DESCRIPTION
There was a closing parenthesis missing, and the title was too big, so it's converted into an abstract+title caption.