### PR TITLE
Refactor syntax of code snippet captions

### DIFF
--- a/math/pi-day-2023-03-14/index.md
+++ b/math/pi-day-2023-03-14/index.md
@@ -41,19 +41,14 @@ natural numbers [1]:
 
 Another example is the creation of the Fibonacci sequence inductively:
 
+`Also Known as "the 'Hello, world!' of Haskell programming" |
+The Fibonacci Sequence [4]`
+
 ```haskell
 fib 0 = 0
 fib 1 = 1
 fib n = fib (n-1) + fib (n-2)
 ```
-
-<p align="center">
-Also Known as "the 'Hello, world!' of Haskell programming"
-</p>
-
-<figcaption>
-<p align="center"><b>The Fibonacci Sequence</b> [4]</p>
-</figcaption>
 
 The declarativeness of math enables creation with mathematical elegance unlike
 the imperativeness of those impure where every instance is to be addressed

--- a/mathswe/eng/automation/platform/ops/automating-the-platform-operations-and-beyond-2023-08-31/index.md
+++ b/mathswe/eng/automation/platform/ops/automating-the-platform-operations-and-beyond-2023-08-31/index.md
@@ -194,17 +194,13 @@ where Jekyll generated the site in the last building step.
 
 The response will be similar to this:
 
+`Command: Serve Project Out`
+
 ```
 [main] INFO ktor.application - Serving P:\tobiasbriones\test-blog-deploy\out\build\test-blog-deploy\_site
 [main] INFO ktor.application - Application started in 0.13 seconds.
 [DefaultDispatcher-worker-1] INFO ktor.application - Responding at http://127.0.0.1:8080
 ```
-
-<figcaption>
-<p align="center"><strong>
-Command: Serve Project Out
-</strong></p>
-</figcaption>
 
 Applications can be locally served with this command after running the build
 plus Jekyll command that puts the output to the `out` building directory.
@@ -252,6 +248,8 @@ itself (simple 👍🏻), similar to how I encoded
 [hyphens and pipes on file names](/how-i-standardized-hyphen-and-pipe-symbols-on-file-names).
 
 You can see how this smart dictionary works from the current spec:
+
+`The Text System is Defining High-Level Titles from Resource IDs`
 
 ```kotlin
 @Test
@@ -314,12 +312,6 @@ fun toTitleCase() {
     cases.forEach { assertEquals(it.value, it.key.toTitleCase(dic)) }
 }
 ```
-
-<figcaption>
-<p align="center"><strong>
-The Text System is Defining High-Level Titles from Resource IDs
-</strong></p>
-</figcaption>
 
 Among other implementation details, semantics like article abstract, headings,
 Jekyll Front Matter, etc., had to be extracted from Markdown.

--- a/swe/design/cs/fp/kotlin/fp-in-kotlin/applying-my-pipe-and-application-operators-in-kotlin-2023-07-19/index.md
+++ b/swe/design/cs/fp/kotlin/fp-in-kotlin/applying-my-pipe-and-application-operators-in-kotlin-2023-07-19/index.md
@@ -11,6 +11,8 @@
 I've been applying the operators I designed a couple of days ago to make
 Kotlin's FP more expressive.
 
+`More Expressive Code with my Pipe and Application Operators`
+
 ```kotlin
 fun exec_build(root: String, entryName: String) {
     entries(root `---` Path::of `---` ::Entry)
@@ -19,14 +21,9 @@ fun exec_build(root: String, entryName: String) {
 }
 ```
 
-<figcaption>
-<p align="center"><strong>
-More Expressive Code with my Pipe and Application Operators
-</strong></p>
-</figcaption>
+`More Conservative Code`
 
 ```kotlin
-
 fun exec_build(root: String, entryName: String) {
     val entry = Entry(Path.of(root))
     entries(entry)
@@ -34,12 +31,6 @@ fun exec_build(root: String, entryName: String) {
         .onSome { build(it, BuildConfig(Path.of(root, "_out"))) }
 }
 ```
-
-<figcaption>
-<p align="center"><strong>
-More Conservative Code
-</strong></p>
-</figcaption>
 
 An original (unheard) FP adage refers to "only transformations," not even
 identifiers. Of course, not even Haskell has that level of pureness. I mention
@@ -74,6 +65,8 @@ how a function can be readably stated or defined at some degree with Kotlin's
 For example, in the following snippet, the function is matched via `=` instead
 of being an imperative block `{}` with all the underlying flaws.
 
+`Example of Matching a Function`
+
 ```kotlin
 enum class Fn {
     Entries,
@@ -87,11 +80,7 @@ fun newFn(value: String): Either<None, Fn> = when (value.lowercase()) {
 }
 ```
 
-<figcaption>
-<p align="center"><strong>
-Example of Matching a Function
-</strong></p>
-</figcaption>
+`Example of Imperative Boilerplate`
 
 ```java
 enum Fn {
@@ -107,12 +96,6 @@ static Optional<Fn> newFn(String value) {
     };
 }
 ```
-
-<figcaption>
-<p align="center"><strong>
-Example of Imperative Boilerplate
-</strong></p>
-</figcaption>
 
 Otherwise, an imperative code block with `return` would've been needed, like the
 above Java snippet —unnecessary. But that's some boilerplate that can be

--- a/swe/design/ts/refactoring/drawing-a-tree-on-canvas-with-xy-coordinates/from-imperative-to-functional-_-typescript-fetch-promise/index.md
+++ b/swe/design/ts/refactoring/drawing-a-tree-on-canvas-with-xy-coordinates/from-imperative-to-functional-_-typescript-fetch-promise/index.md
@@ -18,6 +18,8 @@ the difference **is clear** again.
 
 The difference between both snippets is the following:
 
+`Imperative`
+
 ```ts
 async function fetchTree(path: string): Promise<TreeNode> {
   const onError = reason => showError({ reason, msg: 'Failed to fetch tree' });
@@ -40,10 +42,7 @@ async function fetchTree(path: string): Promise<TreeNode> {
 }
 ```
 
-<figcaption>
-<p align="center"><strong>Imperative</strong></p>
-</figcaption>
-
+`More Functional`
 
 ```ts
 function fetchTree(path: string): Promise<TreeNode> {
@@ -57,10 +56,6 @@ function fetchTree(path: string): Promise<TreeNode> {
     });
 }
 ```
-
-<figcaption>
-<p align="center"><strong>More Functional</strong></p>
-</figcaption>
 
 The refactored code (a.k.a. "more functional") **is not functional**, but it 
 gets close. This is to avoid introducing functional abstractions like pipes, 

--- a/swe/diary/troubleshooting/troubleshooting-diary/index.md
+++ b/swe/diary/troubleshooting/troubleshooting-diary/index.md
@@ -25,6 +25,8 @@ Troubleshooting from my university enrollment sections app are listed next.
 
 This was when Java 9 came out, and reflection operations were affected.
 
+`Illegal Reflective Access Warning in Old Version of Apache POI and Java 9`
+
 ```
 WARNING: An illegal reflective access operation has occurred
 WARNING: Illegal reflective access by org.apache.poi.util.DocumentHelper (file:/T:/Workspace/Java/Sections%20Manager/libs/poi/poi-ooxml-3.17.jar) to method com.sun.org.apache.xerces.internal.util.SecurityManager.setEntityExpansionLimit(int)
@@ -32,12 +34,6 @@ WARNING: Please consider reporting this to the maintainers of org.apache.poi.uti
 WARNING: Use --illegal-access=warn to enable warnings of further illegal reflective access operations
 WARNING: All illegal access operations will be denied in a future release
 ```
-
-<figcaption>
-<p align="center"><strong>
-Illegal Reflective Access Warning in Old Version of Apache POI and Java 9
-</strong></p>
-</figcaption>
 
 Apache POI 3.x is quite old, while 4.x came later.
 
@@ -82,6 +78,8 @@ the `Stream` API that was introduced in Java 16.
 
 **The IDE was all right with the code, but it didn't compile in the end.**
 
+`Method "toList" Unresolved by the Compiler`
+
 ```kotlin
 fun entries(root: Entry): List<Entry> =
     Files
@@ -94,11 +92,7 @@ fun entries(root: Entry): List<Entry> =
         .toList() // <- here
 ```
 
-<figcaption>
-<p align="center"><strong>
-Method "toList" Unresolved by the Compiler
-</strong></p>
-</figcaption>
+`The Method "toList" is not Found when Compiling`
 
 ```
 e: file:///P:/deployment/blog/ops/src/main/kotlin/Main.kt:282:10 Unresolved reference. None of the following candidates is applicable because of receiver type mismatch: 
@@ -120,12 +114,6 @@ public fun <K, V> Map<out TypeVariable(K), TypeVariable(V)>.toList(): List<Pair<
 public fun <T> Sequence<TypeVariable(T)>.toList(): List<TypeVariable(T)> defined in kotlin.sequences
 ```
 
-<figcaption>
-<p align="center"><strong>
-The Method "toList" is not Found when Compiling
-</strong></p>
-</figcaption>
-
 A solution was to add `import kotlin.streams.toList` to import the method
 `toList` so it's found. The problem is that is unnecessary, and **the IDE
 deleted it because it said it was an unused import.**
@@ -140,17 +128,13 @@ stopped compiling some day).
 In the end, I was able to **set the actual version of the JDK to use by Gradle
 by editing the project's `build.gradle.kts` from `11` to `19`** (or the latest):
 
+`Solution to Set the Correct Version of the JDK to Run the Kotlin App`
+
 ```kotlin
 kotlin {
     jvmToolchain(19)
 }
 ```
-
-<figcaption>
-<p align="center"><strong>
-Solution to Set the Correct Version of the JDK to Run the Kotlin App
-</strong></p>
-</figcaption>
 
 ### Machine Learning
 
@@ -169,7 +153,11 @@ learn**, and that was the problem I had.
 
 The API is the following:
 
-`tf.data.Dataset.list_files(split_list, shuffle=False)`
+`Tensorflow "list_files" Method with Explicit File Unshuffling`
+
+```
+tf.data.Dataset.list_files(split_list, shuffle=False)
+```
 
 [list_files \| tf.data.Dataset \| TensorFlow v2.12.0](https://www.tensorflow.org/api_docs/python/tf/data/Dataset#list_files)
 

--- a/swe/lang/fp/kotlin/fp-in-kotlin/index.md
+++ b/swe/lang/fp/kotlin/fp-in-kotlin/index.md
@@ -58,15 +58,11 @@ It's useful for the given example that shows the operator usage:
 
 First, the `---` operator is defined:
 
-`Pipe.kt`
+`Definition of the Pipe ("---") Operator | Pipe.kt`
 
 ```kotlin
 infix fun <X, Y> X.`---`(f: (X) -> Y): Y = f(this)
 ```
-
-<figcaption>
-<p align="center"><strong>Definition of the Pipe ("---") Operator</strong></p>
-</figcaption>
 
 Where:
 
@@ -92,7 +88,7 @@ That was the definition of the pipe operator.
 Now, to address a concrete example to use this new feature, I implemented a
 basic DSL for an `Article` domain type.
 
-`Pipe.kt`
+`Definition of an "Article" DSL | Pipe.kt`
 
 ```kotlin
 data class Article(val title: Title, val content: String)
@@ -105,28 +101,20 @@ value class Title(val value: String) {
 val title: (String) -> Title = { Title(it) }
 ```
 
-<figcaption>
-<p align="center"><strong>Definition of an "Article" DSL</strong></p>
-</figcaption>
-
 So, to test the code, I will add a user input title that is not cleaned, some
 content, and I'll also define more functions with **transformations**, so we can
 *pipe them*.
 
-`fun main | Pipe.kt`
+`Sample User Input for Example Snippet | fun main | Pipe.kt`
 
 ```kotlin
 val inputTitle = "FP in Kotlin: Defining a Pipe   Operator  "
 val inputContent = "Lorem ipsum dolor sit amet..."
 ```
 
-<figcaption>
-<p align="center"><strong>Sample User Input for Example Snippet</strong></p>
-</figcaption>
-
 Then, we'll have some useful example transformations:
 
-`fun main | Pipe.kt`
+`Transformations for Example Snippet | fun main | Pipe.kt`
 
 ```kotlin
 val clean: (String) -> String = { it.trim().replace("\\s+".toRegex(), " ") }
@@ -136,13 +124,9 @@ val formatTitle: (String) -> String =
     { it `---` clean `---` uppercase `---` markdownTitle }
 ```
 
-<figcaption>
-<p align="center"><strong>Transformations for Example Snippet</strong></p>
-</figcaption>
-
 Finally, we can create an `Article` with `title` and `content`:
 
-`fun main | Kotlin.kt`
+`Building an "Article" for the Example Snippet | fun main | Kotlin.kt`
 
 ```kotlin
 print(
@@ -152,11 +136,6 @@ print(
     )
 )
 ```
-
-<figcaption>
-<p align="center"><strong>Building an "Article" for the Example 
-Snippet</strong></p>
-</figcaption>
 
 With this, a title `String` can be transformed into a `Title` domain type by
 piping it to the transformations declared:
@@ -168,16 +147,14 @@ piping it to the transformations declared:
 
 The program's output is:
 
+`Program's Output (Formatted)`
+
 ```
 Article(
     title=# FP IN KOTLIN: DEFINING A PIPE OPERATOR,
     content=Lorem ipsum dolor sit amet...
 )
 ```
-
-<figcaption>
-<p align="center"><strong>Program's Output (Formatted)</strong></p>
-</figcaption>
 
 The example code is [here](kotlin/Pipe.kt).
 


### PR DESCRIPTION
It refactorizes all articles with code snippets to the new (first) standard for code snippet captions.