### PR TITLE
Fix local storage directory creation in building-slides-from-screenshots-app-in-javafx

### DIFF
--- a/swe/dev/java/javafx/drawing/productivity/building-slides-from-screenshots-app-in-javafx/index.md
+++ b/swe/dev/java/javafx/drawing/productivity/building-slides-from-screenshots-app-in-javafx/index.md
@@ -969,15 +969,15 @@ private void loadImageList() {
 private void createOrUpdateImages(Iterable<? extends File> files) {
     for (var file : files) {
         var path = file.toPath();
-    
+
         try {
             repository.createOrUpdateImage(path);
-        
+
             var imageName = path.getFileName().toString();
             var newImage = repository.readImage(imageName);
             var newImageItem = new ImageItem(imageName, newImage);
             var listItems = imageList.getItems();
-        
+
             listItems.remove(newImageItem);
             listItems.add(new ImageItem(imageName, newImage));
         }

--- a/swe/dev/java/javafx/drawing/productivity/building-slides-from-screenshots-app-in-javafx/index.md
+++ b/swe/dev/java/javafx/drawing/productivity/building-slides-from-screenshots-app-in-javafx/index.md
@@ -538,6 +538,8 @@ public class LocalDataRepository implements DataRepository {
 
     @Override
     public List<ImageItem> readAllImages() throws IOException {
+        requireLocalStorage();
+
         var images = new ArrayList<ImageItem>();
         var files = Files
             .walk(pathOf(""), 1)

--- a/swe/dev/java/javafx/drawing/productivity/building-slides-from-screenshots-app-in-javafx/slides---ep/src/main/java/engineer/mathsoftware/blog/slides/data/LocalDataRepository.java
+++ b/swe/dev/java/javafx/drawing/productivity/building-slides-from-screenshots-app-in-javafx/slides---ep/src/main/java/engineer/mathsoftware/blog/slides/data/LocalDataRepository.java
@@ -55,6 +55,8 @@ public class LocalDataRepository implements DataRepository {
 
     @Override
     public List<ImageItem> readAllImages() throws IOException {
+        requireLocalStorage();
+
         var images = new ArrayList<ImageItem>();
         var files = Files
             .walk(pathOf(""), 1)


### PR DESCRIPTION
One check was missing in the method `readAllImages` of `LocalDataRepository` to create the root data directory if needed.