### PR TITLE
Publish introductory-type-theory-notation-summary-2023-12-25

### DIFF
--- a/cs/type/notation/introductory-type-theory-notation-summary-2023-12-25/index.md
+++ b/cs/type/notation/introductory-type-theory-notation-summary-2023-12-25/index.md
@@ -1,0 +1,5 @@
+<!-- Copyright (c) 2023 Tobias Briones. All rights reserved. -->
+<!-- SPDX-License-Identifier: CC-BY-4.0 -->
+<!-- This file is part of https://github.com/tobiasbriones/blog -->
+
+# Introductory Type Theory Notation Summary (2023/12/25)

--- a/cs/type/notation/introductory-type-theory-notation-summary-2023-12-25/index.md
+++ b/cs/type/notation/introductory-type-theory-notation-summary-2023-12-25/index.md
@@ -3,3 +3,8 @@
 <!-- This file is part of https://github.com/tobiasbriones/blog -->
 
 # Introductory Type Theory Notation Summary (2023/12/25)
+
+## Bibliography
+
+- "Types and Programming Languages," by Benjamin C. Pierce.
+- "Foundations" by Jeremy Avigad.

--- a/cs/type/notation/introductory-type-theory-notation-summary-2023-12-25/index.md
+++ b/cs/type/notation/introductory-type-theory-notation-summary-2023-12-25/index.md
@@ -4,6 +4,15 @@
 
 # Introductory Type Theory Notation Summary (2023/12/25)
 
+![](static/introductory-type-theory-notation-summary-2023-12-25.png)
+
+<p align="center">
+<b>
+Background Derived from
+<a href="static/notice">Pixabay</a> Images
+</b>
+</p>
+
 ## Bibliography
 
 - "Types and Programming Languages," by Benjamin C. Pierce.

--- a/cs/type/notation/introductory-type-theory-notation-summary-2023-12-25/index.md
+++ b/cs/type/notation/introductory-type-theory-notation-summary-2023-12-25/index.md
@@ -17,3 +17,7 @@ Background Derived from
 
 - "Types and Programming Languages," by Benjamin C. Pierce.
 - "Foundations" by Jeremy Avigad.
+
+## References
+
+[1] [The HoTT Book](https://homotopytypetheory.org/book/). (2022, March 18). Homotopy Type Theory.

--- a/cs/type/notation/introductory-type-theory-notation-summary-2023-12-25/index.md
+++ b/cs/type/notation/introductory-type-theory-notation-summary-2023-12-25/index.md
@@ -13,6 +13,51 @@ Background Derived from
 </b>
 </p>
 
+I collected an introductory summary as a presentation of the notation used in
+type theory.
+
+The types are presented from easy to advanced concepts.
+
+![](static/type-theory-notations_seq-1.png)
+
+This makes it easy to understand why type parameters (a.k.a. "generic" types)
+are lowercase styled in Haskell because it's a design decision that comes from
+type theory or computer science.
+
+Ordinary languages employ random syntax (probably pragmatic when
+they were created) like uppercase generics or C-like syntax, which are ugly and
+made-up/workarounds[^1].
+
+[^1]: I read long ago that they tried the arrangements of C++ pointer syntax to
+    make "sense" of them, but it ended up as the same workaround mess that
+    language is, so pragmatic designs end up as workarounds rather than real
+    solutions
+
+Regarding type identifiers, modern languages have adopted the syntax `a: A`,
+unlike old languages like C# and Java, which are `A a` C-like. If you notice,
+the syntax `a: A` comes from type theory, and `a` is lowercase to not confuse a
+type variable with its type —the reason why "generics" are lowercase in
+Haskell if you ever wonder[^2].
+
+[^2]: I mention this because coming from banal languages like Java (and all the
+    other mainstream languages) where generic types are uppercase, arises the
+    question of why they look "weird" in functional languages using lowercase
+    for type variables; but it makes perfect sense when you understand the
+    theory —what any professional engineer does
+
+Sets in math are denoted in uppercase since they're abstractions containing
+specific elements (or points in topology, vectors in vector spaces, etc.). Types
+are like sets in CS, so they are denoted in uppercase, and the variables are
+lowercase. Therefore, **we follow informed designs**.
+
+Regarding the last slides, homotopy type theory is a new field of study based on
+a recently discovered connection between homotopy theory and type theory,
+offering a new "univalent" foundation of math [1].
+
+This collection of type theory symbols and notations fundamentally related to
+math and set theory in computer science can help grasp the meaning of concepts
+like lambdas and ADTs as a general reference as well as design decision reasons.
+
 ## Bibliography
 
 - "Types and Programming Languages," by Benjamin C. Pierce.

--- a/cs/type/notation/introductory-type-theory-notation-summary-2023-12-25/static/notice.md
+++ b/cs/type/notation/introductory-type-theory-notation-summary-2023-12-25/static/notice.md
@@ -4,9 +4,34 @@
 
 <img src="introductory-type-theory-notation-summary-2023-12-25.png" alt="cover.png" width="160" />
 
+<img src="type-theory-notations_seq-1.png" alt="cover.png" width="160" />
+
 - [Cover](introductory-type-theory-notation-summary-2023-12-25.png)
     - Derivative from
         - [Mathematics Pay Algebra \| Pixabay](https://pixabay.com/illustrations/mathematics-pay-algebra-character-1044091/)
             - By [geralt](https://pixabay.com/users/geralt-9301/)
     - Under the [Pixabay License](https://pixabay.com/service/terms)
-    - Changes: Merge image with original image
+    - Changes: Use image as the background of the original image
+
+<img src="type-theory-notations_seq-1.png" alt="cover.png" width="160" />
+
+<img src="type-theory-notations_seq-2.png" alt="cover.png" width="160" />
+
+<img src="type-theory-notations_seq-3.png" alt="cover.png" width="160" />
+
+<img src="type-theory-notations_seq-4.png" alt="cover.png" width="160" />
+
+<img src="type-theory-notations_seq-5.png" alt="cover.png" width="160" />
+
+<img src="type-theory-notations_seq-6.png" alt="cover.png" width="160" />
+
+<img src="type-theory-notations_seq-7.png" alt="cover.png" width="160" />
+
+- Presentation Slides: Type Theory Notations
+    - Derivative from
+        - [Staircase, Spiral, Architecture \| Pixabay](https://pixabay.com/photos/staircase-spiral-architecture-600468/)
+            - By [stokpic](https://pixabay.com/users/stokpic-692575/)
+        - [Abstract, Architecture, Contemporary \| Pixabay](https://pixabay.com/photos/abstract-architecture-contemporary-1867937/)
+            - By [Pexels](https://pixabay.com/users/pexels-2286921/)
+    - Under the [Pixabay License](https://pixabay.com/service/terms)
+    - Changes: Use images as the background of the original images

--- a/cs/type/notation/introductory-type-theory-notation-summary-2023-12-25/static/notice.md
+++ b/cs/type/notation/introductory-type-theory-notation-summary-2023-12-25/static/notice.md
@@ -1,0 +1,12 @@
+# Notice
+
+## Derivatives
+
+<img src="introductory-type-theory-notation-summary-2023-12-25.png" alt="cover.png" width="160" />
+
+- [Cover](introductory-type-theory-notation-summary-2023-12-25.png)
+    - Derivative from
+        - [Mathematics Pay Algebra \| Pixabay](https://pixabay.com/illustrations/mathematics-pay-algebra-character-1044091/)
+            - By [geralt](https://pixabay.com/users/geralt-9301/)
+    - Under the [Pixabay License](https://pixabay.com/service/terms)
+    - Changes: Merge image with original image


### PR DESCRIPTION
Publish [Introductory Type Theory Notation Summary (2023/12/25)](https://blog.mathsoftware.engineer/introductory-type-theory-notation-summary-2023-12-25).