### PR TITLE
Fix word "login" meaning to avoid misinterpretation in incremental-deployments-and-researching-cookie-laws-2024-02-09

### DIFF
--- a/mathswe/msw/mvp/eng/ops/pr/incremental-deployments-and-researching-cookie-laws-2024-02-09/index.md
+++ b/mathswe/msw/mvp/eng/ops/pr/incremental-deployments-and-researching-cookie-laws-2024-02-09/index.md
@@ -34,7 +34,7 @@ These expand with other requirements like integrating third-party API consent
 (like Google consent mode).
 
 I don't plan to use cookies heavily, so **normal and healthy cookie usage is
-expected** because you need them, e.g., for saving logins and optimizing
+expected** because you need them, e.g., for saving login tokens and optimizing
 products with analytics.
 
 Cookies are an essential part of any website or web app. So, complying with


### PR DESCRIPTION
I refer to saving *tokens* securely like JWTs in HttpOnly cookies, for example, instead of saving the plain "login" username and password.